### PR TITLE
Add redirect to github examples

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,9 +1,16 @@
 module.exports = {
-  i18n: {
-    locales: ['en'],
-    defaultLocale: 'en',
-  },
-  images: {
-    domains: ['cdn.sanity.io'],
-  },
+    i18n: {
+        locales: ["en"],
+        defaultLocale: "en",
+    },
+    images: {
+        domains: ["cdn.sanity.io"],
+    },
+    async redirects() {
+        return [{
+            source: "/examples",
+            destination: "https://github.com/mlcommons/medperf#experiments",
+            permanent: true,
+        }, ];
+    },
 };


### PR DESCRIPTION
This PR adds a redirect to our github examples. It doesn't add any UI method for reaching that endpoint, but that's not needed for now.